### PR TITLE
fix: Reset feedback when skipping submission

### DIFF
--- a/contexts/FeedbackContext.tsx
+++ b/contexts/FeedbackContext.tsx
@@ -18,6 +18,7 @@ export type FeedbackContextType = {
   setImprovementText: (text: string) => void;
   isTextFieldFocused: boolean;
   setIsTextFieldFocused: Dispatch<SetStateAction<boolean>>;
+  reset: () => void;
   submit: () => void;
 };
 
@@ -32,6 +33,7 @@ const initialState = {
   setImprovementText: noProviderErrorFn,
   isTextFieldFocused: false,
   setIsTextFieldFocused: noProviderErrorFn,
+  reset: noProviderErrorFn,
   submit: noProviderErrorFn,
 };
 
@@ -51,19 +53,24 @@ export const FeedbackProvider = ({ children }: PropsWithChildren) => {
     [setRatingInternal],
   );
 
+  const reset = useCallback(() => {
+    setRatingInternal(undefined);
+    setImprovementText(undefined);
+    setIsTextFieldFocused(false);
+  }, []);
+
   const submit = useCallback(() => {
     let improvementTextToSubmit: string | undefined = improvementText;
     if (improvementText?.trim() === "") {
       improvementTextToSubmit = undefined;
     }
     submitFeedback(rating, improvementTextToSubmit);
-    setRatingInternal(undefined);
-    setImprovementText(undefined);
+    reset();
     addToast({
       type: "success",
       text: dictionary["feedback.thankYou"],
     });
-  }, [improvementText, rating, dictionary]);
+  }, [improvementText, rating, dictionary, reset]);
 
   return (
     <FeedbackContext.Provider
@@ -74,6 +81,7 @@ export const FeedbackProvider = ({ children }: PropsWithChildren) => {
         setImprovementText,
         isTextFieldFocused,
         setIsTextFieldFocused,
+        reset,
         submit,
       }}
     >

--- a/screens/FeedbackScreen/NavigationButtons.tsx
+++ b/screens/FeedbackScreen/NavigationButtons.tsx
@@ -9,12 +9,17 @@ export const NavigationButtons = () => {
   const styles = useFeedbackStyles();
   const dictionary = useDictionary();
   const navigation = useAttenuationAppNavigation();
-  const { improvementText, rating, submit } = useFeedback();
+  const { improvementText, rating, reset, submit } = useFeedback();
 
   const navigate = () => navigation.navigate("WelcomeScreen");
 
   const onPressSubmit = () => {
     submit();
+    navigate();
+  };
+
+  const onPressSkip = () => {
+    reset();
     navigate();
   };
 
@@ -31,7 +36,7 @@ export const NavigationButtons = () => {
       <Button
         variant="outlined"
         title={dictionary["feedbackScreen.skip"]}
-        onPress={navigate}
+        onPress={onPressSkip}
       />
     </View>
   );


### PR DESCRIPTION
This commit aims to prevent unintended feedback from appearing for the next user in the same app session. Previously, if the previous user gave a rating but skipped submitting feedback, the feedback would still appear for the next user. This could lead to the next user accidentally pressing the "Send feedback" button, as it was the primary button displayed.

Closes #58